### PR TITLE
Truffle Sol Unit Test Troubleshooting

### DIFF
--- a/test/TestSplitter.sol
+++ b/test/TestSplitter.sol
@@ -3,24 +3,7 @@ pragma solidity 0.5.2;
 import "truffle/Assert.sol";
 import "truffle/DeployedAddresses.sol";
 import "../contracts/Splitter.sol";
-
-
-contract Actor {
-    function newSplitter(address _r1, address _r2) public returns(Splitter) {
-        return new Splitter(_r1, _r2);
-    }
-
-    function deposit(Splitter _splitter, uint _amount) public {
-        require(address(_splitter) != address(0x0), "splitter is undefined");
-        require(_amount != uint(0), "deposit amount is zero");
-        _splitter.deposit();
-    }
-
-    function withdraw(Splitter _splitter) public {
-        require(address(_splitter) != address(0x0), "splitter is undefined");
-        _splitter.withdraw();
-    }
-}
+import "./helpers/Actor.sol";
 
 contract TestSplitter {    
     function testDeployed() public {

--- a/test/helpers/Actor.sol
+++ b/test/helpers/Actor.sol
@@ -1,0 +1,20 @@
+pragma solidity 0.5.2;
+
+import "../../contracts/Splitter.sol";
+
+contract Actor {
+    function newSplitter(address _r1, address _r2) public returns(Splitter) {
+        return new Splitter(_r1, _r2);
+    }
+
+    function deposit(Splitter _splitter, uint _amount) public {
+        require(address(_splitter) != address(0x0), "splitter is undefined");
+        require(_amount != uint(0), "deposit amount is zero");
+        _splitter.deposit();
+    }
+
+    function withdraw(Splitter _splitter) public {
+        require(address(_splitter) != address(0x0), "splitter is undefined");
+        _splitter.withdraw();
+    }
+}


### PR DESCRIPTION
Hey @feamcor!

Saw your post on spectrum. Currently it appears `truffle test` solidity unit tests need to have their Contracts labeled `TestWhateverContract` (although I believe I recently changed that in trufflesuite/truffle#1878). iirc, any contracts not labeled that way in a given solidity unit test file (that _aren't_ being imported and used in a `TestWhateverContract` Contract), are either completely ignored and/or cause `truffle test` to completely ignore the unit test file (i.e. `TestContract.sol`).

Hopefully the PR linked above fixes this situation, but until we release `5.0.13`, this PR I'm opening should help troubleshoot and get things working. 🤞 